### PR TITLE
Fix temperature scale for zone room temperature

### DIFF
--- a/custom_components/broetje_heating/devices/iwr.py
+++ b/custom_components/broetje_heating/devices/iwr.py
@@ -2443,13 +2443,13 @@ def _build_zone_registers(zones: list[int]) -> dict[str, Any]:
             "data_type": "int16",
             "scale": IWR_SCALE_TEMP,
         }
-        # 1104 - Zone room temperature (INT16, 0.1°C)
+        # 1104 - Zone room temperature (INT16, 0.01°C)
         registers[f"{prefix}_room_temp"] = {
             "address": _zone_addr(1104, z),
             "type": REG_HOLDING,
             "count": 1,
             "data_type": "int16",
-            "scale": IWR_SCALE_ROOM_TEMP,
+            "scale": IWR_SCALE_TEMP,
         }
         # 1105 - Zone room temperature measured (INT16, 0.1°C)
         registers[f"{prefix}_room_temp_measured"] = {


### PR DESCRIPTION
Ne. Mist. Am Handy ist das doof. "Raumtemperatur gemessen" ist falsch...